### PR TITLE
Fixes a small bug in "Check for appimagetool"

### DIFF
--- a/build-appimage.sh
+++ b/build-appimage.sh
@@ -114,11 +114,17 @@ fi
 # Check for appimagetool
 if ! check_command $APP_IMAGE_TOOL; then
     echo "Installing appimagetool..."
-    exit 1
     wget -O /tmp/appimagetool-x86_64.AppImage https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
     chmod +x /tmp/appimagetool-x86_64.AppImage
-    mv /tmp/appimagetool-x86_64.AppImage /usr/local/bin/appimagetool
-    echo "✓ appimagetool installed"
+    echo "Sudo privileges required to install appimagetool to /usr/local/bin/"
+    sudo mv /tmp/appimagetool-x86_64.AppImage /usr/local/bin/appimagetool
+    if [ $? -eq 0 ]; then
+        echo "✓ appimagetool installed successfully"
+        APP_IMAGE_TOOL="/usr/local/bin/appimagetool"
+    else
+        echo "❌ Failed to install appimagetool. Please install it manually or update the APP_IMAGE_TOOL variable."
+        exit 1
+    fi
 fi
 
 # Check for electron - first local, then global


### PR DESCRIPTION
There was a small logical error in appimagetool:

1. It checks if appimagetool is not installed
2. If it's not installed, it says "Installing appimagetool..."
3. But then immediately exits with an error instead of actually installing it

This is now fixed by installing it on-the-fly.